### PR TITLE
feat: api 변경 적용

### DIFF
--- a/app/api/instance.ts
+++ b/app/api/instance.ts
@@ -24,7 +24,7 @@ axiosInstance.interceptors.request.use(
 // 응답 인터셉터
 axiosInstance.interceptors.response.use(
   (response) => {
-    return response.data;
+    return response;
   },
   (error) => {
     if (axios.isAxiosError(error)) {

--- a/app/api/lib/blog-recap/actions.ts
+++ b/app/api/lib/blog-recap/actions.ts
@@ -1,11 +1,11 @@
 "use server";
 
 import API from "@/app/api";
-import { BlogAnalytics } from "./types";
+import { BlogAnalyticsResponse } from "../types";
 
 export const fetchBlogAnalytics = async (id: string) => {
-  const response = await API.get<BlogAnalytics>(`/v1/blog-analytics`, {
+  const response = await API.get<BlogAnalyticsResponse>(`/v2/blog-analytics`, {
     params: { id },
   });
-  return response;
+  return response.data;
 };

--- a/app/api/lib/types.ts
+++ b/app/api/lib/types.ts
@@ -1,3 +1,6 @@
+import { AxiosResponse } from "axios";
+import { BlogAnalytics } from "./blog-recap/types";
+
 export type RootResponse = {
   message: string;
 };
@@ -10,3 +13,5 @@ export type AnalysisFormData = {
 export type TotalPostCount = {
   totalPostCount: string;
 };
+
+export type BlogAnalyticsResponse = AxiosResponse<BlogAnalytics>;

--- a/app/blog-input/type.ts
+++ b/app/blog-input/type.ts
@@ -1,4 +1,5 @@
 import { type BlogDomain } from "@/src/constants/blogs";
+import { AxiosResponse } from "axios";
 import { Dispatch, SetStateAction } from "react";
 
 export type BlogInputModeProps = {
@@ -10,4 +11,6 @@ export type BlogSelectModeProps = {
   setSelectMode: Dispatch<SetStateAction<boolean>>;
 };
 
-export type BlogAnalyticsResponse = { blogAnalyticsId: string };
+export type BlogAnalyticsId = { blogAnalyticsId: string };
+
+export type BlogAnalyticsIdResponse = AxiosResponse<BlogAnalyticsId>;


### PR DESCRIPTION
# api 변경점 적용되었습니다.

## 주요 변경점
### 통신 코드 수정
- 상태 코드에 따라 핸들링 하기 위해 instance.ts의 응답 인터셉터를 수정하였습니다.
- 상기 내용에 따라 응답 type의 이름을 일부 수정하였습니다.
### 컴포넌트 수정
- blog-input-mode에서 post요청을 보낸 후 get요청을 수행합니다.
- get 요청 수행시 202응답에서는 error를, 200에서는 success로 매칭하여 202일때는 2초에 한번 refetch를, 200일때는 /blog-recap으로 이동합니다.

## 남은 작업
- [x] 코드 정리 리팩토링...
- [x] postAnalysis 삭제
